### PR TITLE
x25519_precomputed: use `-march=haswell`

### DIFF
--- a/ext/x25519_precomputed/extconf.rb
+++ b/ext/x25519_precomputed/extconf.rb
@@ -4,7 +4,7 @@
 
 require "mkmf"
 
-$CFLAGS << " -Wall -O3 -pedantic -std=c99 -mbmi -mbmi2 -march=native -mtune=native"
+$CFLAGS << " -Wall -O3 -pedantic -std=c99 -mbmi -mbmi2 -march=haswell"
 
 create_makefile "x25519_precomputed"
 


### PR DESCRIPTION
Closes #22

Changes extconf.rb to specify `-march=haswell` instead of `-march=native`, and removes `-mtune` entirely.

When `native` was supplied as the architecture, it was activating AVX-512 features in certain cases which caused SIGILL inside of `memcpy()` when used in environments where AVX-512 is not supported, as observed in #22.

The runtime CPU detection used by this gem only checks for Haswell features, so this commit adjusts `-march` accordingly.

Additionally removes `-mtune` as it's unhelpful in cases where the binary is being relocated.