### PR TITLE
Create empty Makefile on Apple silicon

### DIFF
--- a/ext/x25519_precomputed/extconf.rb
+++ b/ext/x25519_precomputed/extconf.rb
@@ -2,9 +2,11 @@
 
 # rubocop:disable Style/GlobalVars
 
-unless RUBY_PLATFORM =~ /arm64-darwin/
-  require "mkmf"
+require "mkmf"
 
+if RUBY_PLATFORM =~ /arm64-darwin/
+  File.write("Makefile", "install clean: ;")
+else
   $CFLAGS << " -Wall -O3 -pedantic -std=c99 -mbmi -mbmi2 -march=haswell"
 
   create_makefile "x25519_precomputed"


### PR DESCRIPTION
Workaround for "Makefile not found", as RubyGems always tries to build all extensions:

- https://github.com/rubygems/rubygems/blob/v3.3.22/lib/rubygems/specification.rb#L1604-L1633
- https://github.com/rubygems/rubygems/blob/v3.3.22/lib/rubygems/ext/builder.rb#L20-L23