### PR TITLE
Avoid building precomputed on `aarch64-linux`

### DIFF
--- a/ext/x25519_precomputed/extconf.rb
+++ b/ext/x25519_precomputed/extconf.rb
@@ -4,7 +4,7 @@
 
 require "mkmf"
 
-if RUBY_PLATFORM =~ /arm64-darwin/
+if RUBY_PLATFORM =~ /arm64-darwin|aarch64-linux/
   File.write("Makefile", "install clean: ;")
 else
   $CFLAGS << " -Wall -O3 -pedantic -std=c99 -mbmi -mbmi2 -march=haswell"


### PR DESCRIPTION
Related to #30

- [x] Needs a rebase after #31 