### PR TITLE
Add automatic fallback for non-x86_64 targets

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ CLEAN.include("**/*.o", "**/*.so", "**/*.bundle", "pkg", "tmp")
 
 require "rake/extensiontask"
 %w[precomputed ref10].each do |provider|
-  next if provider == "precomputed" && RUBY_PLATFORM =~ /arm64-darwin/
+  next if provider == "precomputed" && RUBY_PLATFORM !~ /x86_64|x64/
 
   Rake::ExtensionTask.new("x25519_#{provider}") do |ext|
     ext.ext_dir = "ext/x25519_#{provider}"

--- a/ext/x25519_precomputed/extconf.rb
+++ b/ext/x25519_precomputed/extconf.rb
@@ -4,12 +4,12 @@
 
 require "mkmf"
 
-if RUBY_PLATFORM =~ /arm64-darwin|aarch64-linux/
-  File.write("Makefile", "install clean: ;")
-else
+if RUBY_PLATFORM =~ /x86_64|x64/
   $CFLAGS << " -Wall -O3 -pedantic -std=c99 -mbmi -mbmi2 -march=haswell"
 
   create_makefile "x25519_precomputed"
+else
+  File.write("Makefile", "install clean: ;")
 end
 
 # rubocop:enable Style/GlobalVars


### PR DESCRIPTION
Use x25519_precomputed only on x86_64, otherwise generate empty Makefile. This allows build on most (if not all) targets.