### PR TITLE
v1.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.0.11] (2026-01-22)
+
+- [#38](https://github.com/RubyCrypto/x25519/pull/38)
+  Drop support for Ruby 2.5/2.6
+- [#36](https://github.com/RubyCrypto/x25519/pull/36)
+  Add automatic fallback for non-x86_64 targets.
+
+[1.0.11]: https://github.com/RubyCrypto/x25519/compare/v1.0.10...v1.0.11
+
 ## [1.0.10] (2022-10-06)
 
 [1.0.10]: https://github.com/RubyCrypto/x25519/compare/v1.0.9...v1.0.10

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ The optimized [rfc7748_precomputed] implementation was designed by:
 ## License
 
 * Copyright (c) 2017-2018 Armando Faz
-* Copyright (c) 2017-2025 Tony Arcieri
+* Copyright (c) 2017-2026 Tony Arcieri
 
 This gem is available as open source under the terms of the
 BSD-3 Clause License ([LICENSE](./LICENSE))

--- a/lib/x25519/version.rb
+++ b/lib/x25519/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module X25519
-  VERSION = "1.0.10"
+  VERSION = "1.0.11"
 end


### PR DESCRIPTION
- [#38](https://github.com/RubyCrypto/x25519/pull/38) Drop support for Ruby 2.5/2.6
- [#36](https://github.com/RubyCrypto/x25519/pull/36) Add automatic fallback for non-x86_64 targets.
